### PR TITLE
MAINT: Command-line argument for warnings level

### DIFF
--- a/haas/plugins/runner.py
+++ b/haas/plugins/runner.py
@@ -20,11 +20,21 @@ class BaseTestRunner(IRunnerPlugin):
 
     @classmethod
     def from_args(cls, args, arg_prefix):
-        return cls()
+        return cls(warnings=args.warnings)
 
     @classmethod
     def add_parser_arguments(self, parser, option_prefix, dest_prefix):
-        pass
+        parser.add_argument(
+            "--warnings",
+            default=None,
+            choices=[
+                "default", "error", "ignore", "always", "module", "once"
+            ],
+            help=("Warnings filter action, specifying whether warnings "
+                  "during tests are ignored, displayed, or turned into "
+                  "errors. The interpretation of the different choices "
+                  "matches Python's warnings module.")
+        )
 
     def run(self, result_collector, test):
         """Run the given test case or test suite.

--- a/haas/tests/test_plugin_manager.py
+++ b/haas/tests/test_plugin_manager.py
@@ -116,9 +116,11 @@ class TestPluginManager(unittest.TestCase):
 
         # Then
         actions = parser._actions
-        self.assertEqual(len(actions), 1)
-        action, = actions
-        self.assertEqual(action.option_strings, ['--runner'])
+        self.assertEqual(len(actions), 2)
+        runner_action, warnings_action = sorted(
+            actions, key=lambda action: action.dest)
+        self.assertEqual(runner_action.option_strings, ['--runner'])
+        self.assertEqual(warnings_action.option_strings, ['--warnings'])
 
     def test_get_default_driver(self):
         # Given

--- a/haas/tests/test_runner.py
+++ b/haas/tests/test_runner.py
@@ -1,3 +1,5 @@
+from argparse import ArgumentParser
+
 from mock import Mock, patch
 
 from ..plugins.runner import BaseTestRunner
@@ -82,3 +84,22 @@ class TestBaseTestRunner(unittest.TestCase):
         filterwarnings.assert_called_once_with(
             'module', category=DeprecationWarning,
             message='Please use assert\w+ instead.')
+
+    def test_init_from_args(self):
+        # Given
+        parser = ArgumentParser()
+        BaseTestRunner.add_parser_arguments(parser, None, None)
+
+        # When
+        args = parser.parse_args()
+        runner = BaseTestRunner.from_args(args, None)
+
+        # Then
+        self.assertIsNone(runner.warnings)
+
+        # When
+        args = parser.parse_args(["--warnings", "ignore"])
+        runner = BaseTestRunner.from_args(args, None)
+
+        # Then
+        self.assertEqual(runner.warnings, "ignore")


### PR DESCRIPTION
closes #89 

This adds a `--warnings` command-line argument to set the warnings level during test runs.

@sjagoe Is this what you had in mind for #89?