### PR TITLE
Expose the --buffer setting for the parallel test runner too

### DIFF
--- a/haas/plugins/parallel_runner.py
+++ b/haas/plugins/parallel_runner.py
@@ -46,9 +46,9 @@ class ChildResultHandler(IResultHandlerPlugin):
         self.results.append(result)
 
 
-def _run_test_in_process(test_case):
+def _run_test_in_process(test_case, buffer):
     result_handler = ChildResultHandler()
-    result_collector = ResultCollector(buffer=True)
+    result_collector = ResultCollector(buffer=buffer)
     result_collector.add_result_handler(result_handler)
     runner = BaseTestRunner()
     runner.run(result_collector, test_case)
@@ -130,13 +130,15 @@ class ParallelTestRunner(BaseTestRunner):
                 if isinstance(test_case, ModuleImportError):
                     error_tests.append(test_case)
                 else:
+                    # print result.buffer, result.failfast
                     call_result = pool.apply_async(
-                        _run_test_in_process, args=(test_case,),
+                        _run_test_in_process, args=(test_case, result.buffer),
                         callback=callback)
                     call_results.append(call_result)
 
             for test_case in error_tests:
-                collected_result = _run_test_in_process(test_case)
+                collected_result = _run_test_in_process(
+                    test_case, result.buffer)
                 callback(collected_result)
         finally:
             pool.close()

--- a/haas/tests/test_parallel_runner.py
+++ b/haas/tests/test_parallel_runner.py
@@ -295,7 +295,7 @@ class TestParallelTestRunner(unittest.TestCase):
         test_case.test_method = test_method
         test_suite = TestSuite([test_case])
 
-        result_collector = ResultCollector()
+        result_collector = ResultCollector(buffer=False)
         runner = ParallelTestRunner()
 
         patch_stdout = patch('sys.stdout', new=StringIO())


### PR DESCRIPTION
This pull request makes the command-line `--buffer` setting take effect for the parallel test runner too. Since it's off by default, the parallel runner will display the contents of the standard output (and those of the standard error) unless asked not to. Fixes #182.

---

Using the **test_haas_parallel.py** example script from ticket #182:
```
$ haas --runner parallel test_haas_parallel.py
one
two
..
----------------------------------------------------------------------
Ran 2 tests in 0.132s

OK
```

```
$ haas --runner parallel --buffer test_haas_parallel.py
..
----------------------------------------------------------------------
Ran 2 tests in 0.121s

OK
```