### PR TITLE
Do not install mock for testing on python >= 3.3

### DIFF
--- a/haas/plugins/tests/test_coverage.py
+++ b/haas/plugins/tests/test_coverage.py
@@ -13,21 +13,21 @@ except ImportError:
     coverage = None
     Coverage = None
 
-from mock import Mock, patch
 
 from haas.testing import unittest
+from haas.tests.compat import mock
 
 
 @unittest.skipIf(coverage is None, 'Coverage is not installed')
 class TestCoverage(unittest.TestCase):
 
-    @patch('coverage.coverage')
+    @mock.patch('coverage.coverage')
     def test_coverage(self, coverage_func):
-        coverage_object = Mock()
+        coverage_object = mock.Mock()
         coverage_func.return_value = coverage_object
-        coverage_object.start = Mock()
-        coverage_object.stop = Mock()
-        coverage_object.save = Mock()
+        coverage_object.start = mock.Mock()
+        coverage_object.stop = mock.Mock()
+        coverage_object.save = mock.Mock()
 
         cov = Coverage('coverage', True, 'coverage')
         self.assertFalse(coverage_func.called)

--- a/haas/plugins/tests/test_discoverer.py
+++ b/haas/plugins/tests/test_discoverer.py
@@ -12,11 +12,10 @@ import sys
 import tempfile
 import unittest as python_unittest
 
-from mock import Mock, patch
-
 from haas.testing import unittest
 
 from haas.tests import _test_cases, builder
+from haas.tests.compat import mock
 from haas.loader import Loader
 from haas.module_import_error import ModuleImportError
 from haas.suite import find_test_cases, TestSuite
@@ -100,7 +99,7 @@ class TestFindTopLevelDirectory(TestDiscoveryMixin, unittest.TestCase):
                 return path
             return os_path_dirname(path)
 
-        with patch('os.path.dirname', dirname):
+        with mock.patch('os.path.dirname', dirname):
             with self.assertRaises(ValueError):
                 find_top_level_directory(os.path.join(self.tmpdir, *self.dirs))
 
@@ -450,9 +449,9 @@ class TestDiscoverFilteredTests(TestDiscoveryMixin, unittest.TestCase):
         self.assertEqual(test._testMethodName, 'test_method')
 
     def test_discover_no_top_level(self):
-        getcwd = Mock()
+        getcwd = mock.Mock()
         getcwd.return_value = self.tmpdir
-        with patch.object(os, 'getcwd', getcwd):
+        with mock.patch.object(os, 'getcwd', getcwd):
             suite = self.discoverer.discover(
                 'TestCase',
             )

--- a/haas/plugins/tests/test_result_handlers.py
+++ b/haas/plugins/tests/test_result_handlers.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 import statistics
 
-from mock import patch
 from six.moves import StringIO
 
 from haas.result import TestResult, TestCompletionStatus, TestDuration
 from haas.testing import unittest
 from haas.tests import _test_cases
+from haas.tests.compat import mock
 from haas.tests.fixtures import ExcInfoFixture
 from ..result_handler import (
     QuietTestResultHandler,
@@ -19,7 +19,7 @@ from ..result_handler import (
 
 class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_start_test_run(self, stderr):
         # Given
         handler = TimingResultHandler(number_to_summarize=5)
@@ -31,7 +31,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_stop_test_run_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -56,8 +56,8 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?00:10\.123 test_method \(')
 
-    @patch('time.ctime')
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('time.ctime')
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_start_test(self, stderr, mock_ctime):
         # Given
         case = _test_cases.TestCase('test_method')
@@ -70,7 +70,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_stop_test(self, stderr):
         # Given
         handler = TimingResultHandler(number_to_summarize=5)
@@ -83,7 +83,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_error(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -105,7 +105,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_failure(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -127,7 +127,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -147,7 +147,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_skip(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -168,7 +168,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_expected_fail(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -190,7 +190,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_unexpected_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -210,7 +210,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_with_error_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -237,7 +237,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?1543:00:12\.234 test_method \(')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_with_failure_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -297,7 +297,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
 
         return _format_stat_table(pairs)
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_multiple_tests(self, stderr):
         # Given
         tests_start_time = datetime(2015, 12, 23, 8, 14, 12)

--- a/haas/tests/compat.py
+++ b/haas/tests/compat.py
@@ -1,0 +1,4 @@
+try:
+    from unittest import mock
+except ImportError:
+    import mock

--- a/haas/tests/compat.py
+++ b/haas/tests/compat.py
@@ -1,4 +1,4 @@
 try:
-    from unittest import mock
+    from unittest import mock  # noqa
 except ImportError:
-    import mock
+    import mock  # noqa

--- a/haas/tests/test_buffering.py
+++ b/haas/tests/test_buffering.py
@@ -9,9 +9,9 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime, timedelta
 import sys
 
-from mock import Mock, patch
 from six.moves import StringIO
 
+from haas.tests.compat import mock
 from ..plugins.i_result_handler_plugin import IResultHandlerPlugin
 from ..result import (
     ResultCollector, TestResult, TestCompletionStatus, TestDuration
@@ -23,10 +23,10 @@ from .fixtures import ExcInfoFixture, MockDateTime
 
 class TestBuffering(ExcInfoFixture, unittest.TestCase):
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_buffering_stderr(self, stderr):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector(buffer=True)
         collector.add_result_handler(handler)
         test_stderr = 'My Test Output'
@@ -37,7 +37,7 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -56,7 +56,7 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
                 case, TestCompletionStatus.error, expected_duration,
                 exception=exc_info, stderr=test_stderr)
             # When
-            with patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
         collector.stopTest(case)
 
@@ -64,10 +64,10 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
         self.assertIn(test_stderr, expected_result.exception)
         handler.assert_called_once_with(expected_result)
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
     def test_buffering_stdout(self, stdout):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector(buffer=True)
         collector.add_result_handler(handler)
         test_stdout = 'My Test Output'
@@ -78,7 +78,7 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -98,7 +98,7 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info, stdout=test_stdout)
 
             # When
-            with patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
         collector.stopTest(case)
 

--- a/haas/tests/test_buffering.py
+++ b/haas/tests/test_buffering.py
@@ -56,7 +56,8 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
                 case, TestCompletionStatus.error, expected_duration,
                 exception=exc_info, stderr=test_stderr)
             # When
-            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch(
+                    'haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
         collector.stopTest(case)
 
@@ -98,7 +99,8 @@ class TestBuffering(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info, stdout=test_stdout)
 
             # When
-            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch(
+                    'haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
         collector.stopTest(case)
 

--- a/haas/tests/test_haas_application.py
+++ b/haas/tests/test_haas_application.py
@@ -16,7 +16,6 @@ import tempfile
 import types
 
 from testfixtures import LogCapture
-
 from stevedore.extension import ExtensionManager, Extension
 
 import haas
@@ -48,7 +47,8 @@ def with_patched_test_runner(fn):
     @wraps(fn)
     def wrapper(*args):
         with mock.patch('haas.haas_application.ResultCollector') as result_cls:
-            with mock.patch('haas.plugins.runner.BaseTestRunner') as runner_class:
+            with mock.patch(
+                    'haas.plugins.runner.BaseTestRunner') as runner_class:
                 environment_manager = ExtensionManager.make_test_instance(
                     [], namespace=PluginManager.ENVIRONMENT_HOOK,
                 )

--- a/haas/tests/test_haas_application.py
+++ b/haas/tests/test_haas_application.py
@@ -15,7 +15,6 @@ import shutil
 import tempfile
 import types
 
-from mock import Mock, patch
 from testfixtures import LogCapture
 
 from stevedore.extension import ExtensionManager, Extension
@@ -28,6 +27,7 @@ from ..plugins.discoverer import Discoverer
 from ..suite import TestSuite
 from ..testing import unittest
 from ..utils import cd
+from .compat import mock
 from . import builder
 
 
@@ -47,8 +47,8 @@ class MockLambda(object):
 def with_patched_test_runner(fn):
     @wraps(fn)
     def wrapper(*args):
-        with patch('haas.haas_application.ResultCollector') as result_cls:
-            with patch('haas.plugins.runner.BaseTestRunner') as runner_class:
+        with mock.patch('haas.haas_application.ResultCollector') as result_cls:
+            with mock.patch('haas.plugins.runner.BaseTestRunner') as runner_class:
                 environment_manager = ExtensionManager.make_test_instance(
                     [], namespace=PluginManager.ENVIRONMENT_HOOK,
                 )
@@ -90,13 +90,13 @@ class TestHaasApplication(unittest.TestCase):
 
     def _run_with_arguments(self, runner_class, result_class, *args, **kwargs):
         plugin_manager = kwargs.get('plugin_manager')
-        runner = Mock()
+        runner = mock.Mock()
         runner_class.from_args.return_value = runner
 
-        result = Mock()
-        result.wasSuccessful = Mock()
+        result = mock.Mock()
+        result.wasSuccessful = mock.Mock()
         result_class.return_value = result
-        run_method = Mock(return_value=result)
+        run_method = mock.Mock(return_value=result)
         runner.run = run_method
 
         app = HaasApplication(['argv0'] + list(args))
@@ -177,13 +177,13 @@ class TestHaasApplication(unittest.TestCase):
         run.assert_called_once_with(result, suite)
         result.wasSuccessful.assert_called_once_with()
 
-    @patch('sys.stdout')
-    @patch('sys.stderr')
-    @patch('haas.plugins.runner.BaseTestRunner')
+    @mock.patch('sys.stdout')
+    @mock.patch('sys.stderr')
+    @mock.patch('haas.plugins.runner.BaseTestRunner')
     def test_main_quiet_and_verbose_not_allowed(self,
                                                 runner_class, stdout, stderr):
         with self.assertRaises(SystemExit):
-            self._run_with_arguments(runner_class, Mock(), '-q', '-v')
+            self._run_with_arguments(runner_class, mock.Mock(), '-q', '-v')
 
     @with_patched_test_runner
     def test_main_verbose(self, runner_class, result_class, plugin_manager):
@@ -248,12 +248,12 @@ class TestHaasApplication(unittest.TestCase):
         run.assert_called_once_with(result, suite)
         result.wasSuccessful.assert_called_once_with()
 
-    @patch('logging.getLogger')
+    @mock.patch('logging.getLogger')
     @with_patched_test_runner
     def test_with_logging(self, get_logger, runner_class, result_class,
                           plugin_manager):
         # Given
-        logger = Mock()
+        logger = mock.Mock()
         get_logger.side_effect = lambda name: logger
 
         with self._basic_test_fixture() as package_name:
@@ -276,13 +276,13 @@ class TestHaasApplication(unittest.TestCase):
         run.assert_called_once_with(result, suite)
         result.wasSuccessful.assert_called_once_with()
 
-    @patch('logging.getLogger')
+    @mock.patch('logging.getLogger')
     @with_patched_test_runner
     def test_with_logging_uppercase_loglevel(self, get_logger,
                                              runner_class, result_class,
                                              plugin_manager):
         # Given
-        logger = Mock()
+        logger = mock.Mock()
         get_logger.side_effect = lambda name: logger
 
         with self._basic_test_fixture() as package_name:
@@ -305,15 +305,15 @@ class TestHaasApplication(unittest.TestCase):
         run.assert_called_once_with(result, suite)
         result.wasSuccessful.assert_called_once_with()
 
-    @patch('sys.stdout')
-    @patch('sys.stderr')
-    @patch('coverage.coverage')
-    @patch('haas.plugins.runner.BaseTestRunner')
+    @mock.patch('sys.stdout')
+    @mock.patch('sys.stderr')
+    @mock.patch('coverage.coverage')
+    @mock.patch('haas.plugins.runner.BaseTestRunner')
     def test_with_coverage_plugin(self, runner_class, coverage,
                                   stdout, stderr):
         # When
         run, result = self._run_with_arguments(
-            runner_class, Mock(), '--with-coverage')
+            runner_class, mock.Mock(), '--with-coverage')
 
         # Then
         coverage.assert_called_once_with()

--- a/haas/tests/test_parallel_runner.py
+++ b/haas/tests/test_parallel_runner.py
@@ -2,7 +2,6 @@ from argparse import ArgumentParser
 from datetime import datetime, timedelta
 import time
 
-from mock import Mock, patch
 from six.moves import StringIO
 
 from ..plugins.discoverer import _create_import_error_test
@@ -13,6 +12,7 @@ from ..suite import TestSuite
 from ..testing import unittest
 from . import _test_cases
 from .fixtures import MockDateTime
+from .compat import mock
 
 
 class AsyncResult(object):
@@ -37,8 +37,8 @@ def apply_async(func, args=None, kwargs=None, callback=None):
 
 class TestChildResultHandler(unittest.TestCase):
 
-    @patch('sys.stderr', new_callable=StringIO)
-    @patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
     def test_basic_workflow(self, stdout, stderr):
         # Given
         handler = ChildResultHandler()
@@ -85,10 +85,10 @@ class TestChildResultHandler(unittest.TestCase):
 
 class TestParallelTestRunner(unittest.TestCase):
 
-    @patch('haas.plugins.parallel_runner.Pool')
+    @mock.patch('haas.plugins.parallel_runner.Pool')
     def test_parallel_test_runner_mock_subprocess(self, pool_class):
         # Given
-        pool = Mock()
+        pool = mock.Mock()
         pool_class.return_value = pool
         pool.apply_async.side_effect = apply_async
 
@@ -111,7 +111,7 @@ class TestParallelTestRunner(unittest.TestCase):
         runner = ParallelTestRunner(processes)
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(
+        with mock.patch('haas.result.datetime', new=MockDateTime(
                 [start_time, end_time])):
             runner.run(result_collector, test_suite)
 
@@ -123,17 +123,17 @@ class TestParallelTestRunner(unittest.TestCase):
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 
-    @patch('haas.plugins.parallel_runner.Pool')
+    @mock.patch('haas.plugins.parallel_runner.Pool')
     def test_parallel_runner_single_start_stop_test_run(self, pool_class):
         # Given
-        pool = Mock()
+        pool = mock.Mock()
         pool_class.return_value = pool
         pool.apply_async.side_effect = apply_async
 
         test_case = _test_cases.TestCase('test_method')
         test_suite = TestSuite([test_case])
 
-        result_collector = Mock()
+        result_collector = mock.Mock()
         runner = ParallelTestRunner()
 
         # When
@@ -148,11 +148,11 @@ class TestParallelTestRunner(unittest.TestCase):
         result_collector.startTestRun.assert_called_once_with()
         result_collector.stopTestRun.assert_called_once_with()
 
-    @patch('haas.plugins.parallel_runner.Pool')
+    @mock.patch('haas.plugins.parallel_runner.Pool')
     def test_parallel_runner_initializer(self, pool_class):
         # Given
-        initializer = Mock()
-        pool = Mock()
+        initializer = mock.Mock()
+        pool = mock.Mock()
         pool_class.return_value = pool
         pool.apply_async.side_effect = apply_async
 
@@ -175,7 +175,7 @@ class TestParallelTestRunner(unittest.TestCase):
         runner = ParallelTestRunner(processes, initializer=initializer)
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(
+        with mock.patch('haas.result.datetime', new=MockDateTime(
                 [start_time, end_time])):
             runner.run(result_collector, test_suite)
 
@@ -187,10 +187,10 @@ class TestParallelTestRunner(unittest.TestCase):
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 
-    @patch('haas.plugins.parallel_runner.Pool')
+    @mock.patch('haas.plugins.parallel_runner.Pool')
     def test_parallel_runner_constructor_processes(self, pool_class):
         # Given
-        pool = Mock()
+        pool = mock.Mock()
         pool_class.return_value = pool
         pool.apply_async.side_effect = apply_async
 
@@ -219,7 +219,7 @@ class TestParallelTestRunner(unittest.TestCase):
         runner = ParallelTestRunner.from_args(args, dest_prefix)
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(
+        with mock.patch('haas.result.datetime', new=MockDateTime(
                 [start_time, end_time])):
             runner.run(result_collector, test_suite)
 
@@ -230,10 +230,10 @@ class TestParallelTestRunner(unittest.TestCase):
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 
-    @patch('haas.plugins.parallel_runner.Pool')
+    @mock.patch('haas.plugins.parallel_runner.Pool')
     def test_parallel_runner_constructor_initializer(self, pool_class):
         # Given
-        pool = Mock()
+        pool = mock.Mock()
         pool_class.return_value = pool
         pool.apply_async.side_effect = apply_async
 
@@ -263,7 +263,7 @@ class TestParallelTestRunner(unittest.TestCase):
         runner = ParallelTestRunner.from_args(args, dest_prefix)
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(
+        with mock.patch('haas.result.datetime', new=MockDateTime(
                 [start_time, end_time])):
             runner.run(result_collector, test_suite)
 
@@ -280,10 +280,10 @@ class TestParallelTestRunner(unittest.TestCase):
 
 class TestParallelRunnerImportError(unittest.TestCase):
 
-    @patch('haas.plugins.parallel_runner.Pool')
+    @mock.patch('haas.plugins.parallel_runner.Pool')
     def test_parallel_distribute_module_import_error(self, pool_class):
         # Given
-        pool = Mock()
+        pool = mock.Mock()
         pool_class.return_value = pool
 
         try:

--- a/haas/tests/test_plugin_context.py
+++ b/haas/tests/test_plugin_context.py
@@ -11,6 +11,7 @@ from ..plugin_context import PluginContext
 from ..testing import unittest
 from .compat import mock
 
+
 class TestPluginContext(unittest.TestCase):
 
     def test_empty_plugin_context(self):

--- a/haas/tests/test_plugin_context.py
+++ b/haas/tests/test_plugin_context.py
@@ -6,11 +6,10 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
-from mock import Mock
 
 from ..plugin_context import PluginContext
 from ..testing import unittest
-
+from .compat import mock
 
 class TestPluginContext(unittest.TestCase):
 
@@ -36,9 +35,9 @@ class TestPluginContext(unittest.TestCase):
             pass
 
     def test_plugin_context_with_plugin(self):
-        plugin = Mock()
-        plugin.setup = Mock()
-        plugin.teardown = Mock()
+        plugin = mock.Mock()
+        plugin.setup = mock.Mock()
+        plugin.teardown = mock.Mock()
         context = PluginContext([plugin])
         self.assertEqual(context.hooks, (plugin,))
         # This should not raise

--- a/haas/tests/test_quiet_result_handler.py
+++ b/haas/tests/test_quiet_result_handler.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime, timedelta
 
-from mock import patch
 from six.moves import StringIO
 
 from ..plugins.result_handler import QuietTestResultHandler
@@ -17,11 +16,12 @@ from ..result import (
 from ..testing import unittest
 from . import _test_cases
 from .fixtures import ExcInfoFixture
+from .compat import mock
 
 
 class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_start_test_run(self, stderr):
         # Given
         handler = QuietTestResultHandler(test_count=1)
@@ -33,7 +33,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_stop_test_run(self, stderr):
         # Given
         handler = QuietTestResultHandler(test_count=1)
@@ -49,7 +49,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?Ran 0 tests.*?OK')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_start_test(self, stderr):
         # Given
         handler = QuietTestResultHandler(test_count=1)
@@ -62,7 +62,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_stop_test(self, stderr):
         # Given
         handler = QuietTestResultHandler(test_count=1)
@@ -75,7 +75,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_error(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -97,7 +97,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_failure(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -119,7 +119,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -139,7 +139,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_skip(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -160,7 +160,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_expected_fail(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -182,7 +182,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_unexpected_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -202,7 +202,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_with_error_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -230,7 +230,7 @@ class TestQuietResultHandler(ExcInfoFixture, unittest.TestCase):
             output, '{0}.*?Traceback.*?RuntimeError'.format(
                 description))
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_with_failure_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)

--- a/haas/tests/test_runner.py
+++ b/haas/tests/test_runner.py
@@ -1,16 +1,15 @@
 from argparse import ArgumentParser
 
-from mock import Mock, patch
-
 from ..plugins.runner import BaseTestRunner
 from ..testing import unittest
+from .compat import mock
 
 
 class TestBaseTestRunner(unittest.TestCase):
 
-    @patch('warnings.filterwarnings')
-    @patch('warnings.simplefilter')
-    @patch('warnings.catch_warnings')
+    @mock.patch('warnings.filterwarnings')
+    @mock.patch('warnings.simplefilter')
+    @mock.patch('warnings.catch_warnings')
     def test_run_tests_no_warning_capture(self, catch_warnings, simplefilter,
                                           filterwarnings):
         # Given
@@ -18,7 +17,7 @@ class TestBaseTestRunner(unittest.TestCase):
         def test(result):
             self.test_result = result
         self.test_result = None
-        result_collector = Mock()
+        result_collector = mock.Mock()
         test_runner = BaseTestRunner()
 
         # When
@@ -33,9 +32,9 @@ class TestBaseTestRunner(unittest.TestCase):
         self.assertFalse(simplefilter.called)
         self.assertFalse(filterwarnings.called)
 
-    @patch('warnings.filterwarnings')
-    @patch('warnings.simplefilter')
-    @patch('warnings.catch_warnings')
+    @mock.patch('warnings.filterwarnings')
+    @mock.patch('warnings.simplefilter')
+    @mock.patch('warnings.catch_warnings')
     def test_run_tests_ignore_warnings(self, catch_warnings, simplefilter,
                                        filterwarnings):
         # Given
@@ -43,7 +42,7 @@ class TestBaseTestRunner(unittest.TestCase):
         def test(result):
             self.test_result = result
         self.test_result = None
-        result_collector = Mock()
+        result_collector = mock.Mock()
         test_runner = BaseTestRunner(warnings='ignore')
 
         # When
@@ -58,9 +57,9 @@ class TestBaseTestRunner(unittest.TestCase):
         simplefilter.assert_called_once_with('ignore')
         self.assertFalse(filterwarnings.called)
 
-    @patch('warnings.filterwarnings')
-    @patch('warnings.simplefilter')
-    @patch('warnings.catch_warnings')
+    @mock.patch('warnings.filterwarnings')
+    @mock.patch('warnings.simplefilter')
+    @mock.patch('warnings.catch_warnings')
     def test_run_tests_always_warn(self, catch_warnings, simplefilter,
                                    filterwarnings):
         # Given
@@ -68,7 +67,7 @@ class TestBaseTestRunner(unittest.TestCase):
         def test(result):
             self.test_result = result
         self.test_result = None
-        result_collector = Mock()
+        result_collector = mock.Mock()
         test_runner = BaseTestRunner(warnings='always')
 
         # When

--- a/haas/tests/test_standard_result_handler.py
+++ b/haas/tests/test_standard_result_handler.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime, timedelta
 
-from mock import patch
 from six.moves import StringIO
 
 from ..plugins.result_handler import StandardTestResultHandler
@@ -17,11 +16,12 @@ from ..result import (
 from ..testing import unittest
 from . import _test_cases
 from .fixtures import ExcInfoFixture
+from .compat import mock
 
 
 class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_start_test_run(self, stderr):
         # Given
         handler = StandardTestResultHandler(test_count=1)
@@ -33,7 +33,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_stop_test_run(self, stderr):
         # Given
         handler = StandardTestResultHandler(test_count=1)
@@ -49,7 +49,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?Ran 0 tests.*?OK')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_start_test(self, stderr):
         # Given
         handler = StandardTestResultHandler(test_count=1)
@@ -62,7 +62,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_stop_test(self, stderr):
         # Given
         handler = StandardTestResultHandler(test_count=1)
@@ -75,7 +75,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_error(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -97,7 +97,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'E')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_failure(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -119,7 +119,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'F')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -139,7 +139,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '.')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_skip(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -160,7 +160,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 's')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_expected_fail(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -182,7 +182,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'x')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_on_unexpected_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -202,7 +202,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'u')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_with_error_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -230,7 +230,7 @@ class TestStandardResultHandler(ExcInfoFixture, unittest.TestCase):
             output, '{0}.*?Traceback.*?RuntimeError'.format(
                 description))
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_with_failure_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)

--- a/haas/tests/test_text_test_result.py
+++ b/haas/tests/test_text_test_result.py
@@ -8,8 +8,6 @@ from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime, timedelta
 
-from mock import Mock, patch
-
 from ..plugins.i_result_handler_plugin import IResultHandlerPlugin
 from ..result import (
     ResultCollector, TestResult, TestCompletionStatus, TestDuration
@@ -17,13 +15,14 @@ from ..result import (
 from ..testing import unittest
 from . import _test_cases, _test_case_data
 from .fixtures import ExcInfoFixture, MockDateTime
+from .compat import mock
 
 
 class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_start_stop_methods(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         case = _test_cases.TestCase('test_method')
@@ -74,7 +73,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_unicode_traceback(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -84,7 +83,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -98,7 +97,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 case, TestCompletionStatus.error, expected_duration,
                 exception=exc_info)
             # When
-            with patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
 
         # Then
@@ -111,7 +110,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_on_error(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -121,7 +120,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -136,7 +135,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info)
 
             # When
-            with patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
 
         # Then
@@ -149,7 +148,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_on_failure(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -159,7 +158,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -173,7 +172,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info)
 
             # When
-            with patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addFailure(case, exc_info)
 
         # Then
@@ -186,7 +185,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_on_success(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -196,7 +195,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -208,7 +207,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
             case, TestCompletionStatus.success, expected_duration)
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(end_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
             collector.addSuccess(case)
 
         # Then
@@ -221,7 +220,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_on_skip(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -231,7 +230,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -244,7 +243,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
             message='reason')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(end_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
             collector.addSkip(case, 'reason')
 
         # Then
@@ -257,7 +256,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_on_expected_fail(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -267,7 +266,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -281,7 +280,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info)
 
             # When
-            with patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addExpectedFailure(case, exc_info)
 
         # Then
@@ -294,7 +293,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
 
     def test_result_collector_calls_handlers_on_unexpected_success(self):
         # Given
-        handler = Mock(spec=IResultHandlerPlugin)
+        handler = mock.Mock(spec=IResultHandlerPlugin)
         collector = ResultCollector()
         collector.add_result_handler(handler)
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -304,7 +303,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         case = _test_cases.TestCase('test_method')
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(start_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(start_time)):
             collector.startTest(case)
 
         # Then
@@ -316,7 +315,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
             case, TestCompletionStatus.unexpected_success, expected_duration)
 
         # When
-        with patch('haas.result.datetime', new=MockDateTime(end_time)):
+        with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
             collector.addUnexpectedSuccess(case)
 
         # Then
@@ -350,7 +349,7 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         tear_down_end_time = datetime(2016, 4, 12, 8, 17, 39)
 
         # When
-        with patch('haas.result.datetime',
+        with mock.patch('haas.result.datetime',
                    new=MockDateTime([start_time, test_end_time,
                                      tear_down_end_time])):
             case.run(collector)

--- a/haas/tests/test_text_test_result.py
+++ b/haas/tests/test_text_test_result.py
@@ -97,7 +97,8 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 case, TestCompletionStatus.error, expected_duration,
                 exception=exc_info)
             # When
-            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch(
+                    'haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
 
         # Then
@@ -135,7 +136,8 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info)
 
             # When
-            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch(
+                    'haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addError(case, exc_info)
 
         # Then
@@ -172,7 +174,8 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info)
 
             # When
-            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch(
+                    'haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addFailure(case, exc_info)
 
         # Then
@@ -280,7 +283,8 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
                 exception=exc_info)
 
             # When
-            with mock.patch('haas.result.datetime', new=MockDateTime(end_time)):
+            with mock.patch(
+                    'haas.result.datetime', new=MockDateTime(end_time)):
                 collector.addExpectedFailure(case, exc_info)
 
         # Then
@@ -349,9 +353,10 @@ class TestTextTestResult(ExcInfoFixture, unittest.TestCase):
         tear_down_end_time = datetime(2016, 4, 12, 8, 17, 39)
 
         # When
-        with mock.patch('haas.result.datetime',
-                   new=MockDateTime([start_time, test_end_time,
-                                     tear_down_end_time])):
+        with mock.patch(
+                'haas.result.datetime',
+                new=MockDateTime(
+                    [start_time, test_end_time, tear_down_end_time])):
             case.run(collector)
 
         # Then

--- a/haas/tests/test_utils.py
+++ b/haas/tests/test_utils.py
@@ -12,6 +12,7 @@ from ..testing import unittest
 from ..utils import configure_logging
 from .compat import mock
 
+
 class TestConfigureLogging(unittest.TestCase):
 
     @mock.patch('logging.getLogger')

--- a/haas/tests/test_utils.py
+++ b/haas/tests/test_utils.py
@@ -6,16 +6,15 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
-from mock import patch
 
 import haas
 from ..testing import unittest
 from ..utils import configure_logging
-
+from .compat import mock
 
 class TestConfigureLogging(unittest.TestCase):
 
-    @patch('logging.getLogger')
+    @mock.patch('logging.getLogger')
     def test_configure_logging(self, get_logger):
         configure_logging('debug')
         get_logger.assert_called_once_with(haas.__name__)

--- a/haas/tests/test_verbose_result_handler.py
+++ b/haas/tests/test_verbose_result_handler.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime, timedelta
 from time import ctime
 
-from mock import patch
 from six.moves import StringIO
 
 from ..plugins.result_handler import VerboseTestResultHandler
@@ -18,11 +17,12 @@ from ..result import (
 from ..testing import unittest
 from . import _test_cases
 from .fixtures import ExcInfoFixture
+from .compat import mock
 
 
 class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_start_test_run(self, stderr):
         # Given
         handler = VerboseTestResultHandler(test_count=1)
@@ -34,7 +34,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_stop_test_run(self, stderr):
         # Given
         handler = VerboseTestResultHandler(test_count=1)
@@ -50,8 +50,8 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?Ran 0 tests.*?OK')
 
-    @patch('time.ctime')
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('time.ctime')
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_start_test(self, stderr, mock_ctime):
         # Given
         case = _test_cases.TestCase('test_method')
@@ -68,7 +68,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
             output, '[{0}] (1/1) {1} ... '.format(
                 expected_time, expected_description))
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_no_output_stop_test(self, stderr):
         # Given
         handler = VerboseTestResultHandler(test_count=1)
@@ -81,7 +81,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, '')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_error(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -103,7 +103,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'ERROR\n')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_failure(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -125,7 +125,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'FAIL\n')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -145,7 +145,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'ok\n')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_skip(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -166,7 +166,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'skipped \'reason\'\n')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_expected_fail(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -188,7 +188,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'expected failure\n')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_on_unexpected_success(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -208,7 +208,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
         output = stderr.getvalue()
         self.assertEqual(output, 'unexpected success\n')
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_with_error_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)
@@ -236,7 +236,7 @@ class TestVerboseResultHandler(ExcInfoFixture, unittest.TestCase):
             output, '{0}.*?Traceback.*?RuntimeError'.format(
                 description))
 
-    @patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stderr', new_callable=StringIO)
     def test_output_with_failure_on_stop_test_run(self, stderr):
         # Given
         start_time = datetime(2015, 12, 23, 8, 14, 12)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 coverage
 unittest2; python_version == '2.6'
-mock
+mock; python_version < '3.3'
 six
 testfixtures


### PR DESCRIPTION
Update the test code so that we use the stdlib mock when available in the tests 